### PR TITLE
Add logging and error handling

### DIFF
--- a/flyway-entrypoint.sh
+++ b/flyway-entrypoint.sh
@@ -1,19 +1,33 @@
 #! /bin/bash -e
 
 function vault_token() {
-  curl --fail --silent -X POST \
+  set -e
+
+  echo "Attempting vault approle login: " \
+    "VAULT_CONNECT=${VAULT_CONNECT}, " \
+    "ROLE_ID=${VAULT_ROLE_ID:0:4}***, " \
+    "SECRET_ID=${VAULT_SECRET_ID:0:4}***" >&2
+
+  result=$(curl -fsS -X POST \
     -d "{\"role_id\": \"$VAULT_ROLE_ID\", \"secret_id\": \"$VAULT_SECRET_ID\"}" \
-    $VAULT_CONNECT/v1/auth/approle/login \
-    | jq -r '.auth.client_token'
+    $VAULT_CONNECT/v1/auth/approle/login)
+
+   echo "$result" | jq -r '.auth.client_token'
 }
 
-function vault_db_lease {
-  local default='{}'
-  local secret=$(curl --fail --silent -X GET \
-    -H "X-Vault-Token: $token" "$VAULT_CONNECT/v1/$VAULT_DB_PATH/creds/$VAULT_DB_ROLE" \
-    | jq '.data')
+function vault_db_lease() {
+  set -e
 
-  echo ${secret:-$default}
+  vault_path="$VAULT_CONNECT/v1/$VAULT_DB_PATH/creds/$VAULT_DB_ROLE"
+
+  echo "Attempting to get vault lease: " \
+    "VAULT_CONNECT=${vault_path}, " \
+    "TOKEN=${token:0:4}***" >&2
+
+  result=$(curl -fsS -X GET \
+    -H "X-Vault-Token: $token" "$vault_path")
+
+   echo "$result" | jq '.data'
 }
 
 token=$(vault_token)
@@ -21,4 +35,5 @@ creds=$(vault_db_lease)
 username=$(echo $creds | jq -r '.username')
 password=$(echo $creds | jq -r '.password')
 
+echo "Running flyway for user ${username}" >&2
 ./flyway -user="$username" -password="$password" "$@"


### PR DESCRIPTION
Some simple logging to `stderr` and a little more failure handling:

+ `set -e` in the functions
+ call `curl` in separate steps to allow for failure
+ add `-S` to curl to get error output
+ don't have a default in the case that the curl command fails
+ log some basic info about the vault calls and results